### PR TITLE
feat: Add template API documentation and update OpenAPI spec

### DIFF
--- a/docs/api/api-v1/_category_.json
+++ b/docs/api/api-v1/_category_.json
@@ -1,7 +1,0 @@
-{
-  "label": "Lumin Sign API v1",
-  "position": 5,
-  "link": {
-    "type": "generated-index"
-  }
-}

--- a/docs/api/authentication.mdx
+++ b/docs/api/authentication.mdx
@@ -27,9 +27,9 @@ curl -XGET 'https://api.luminpdf.com/v1/user/info' -u "${API_KEY}:"
 ```
 
 ## Multiple API Keys
-Lumin Sign allow you to create multiple API Keys for your account.
+Lumin allow you to create multiple API Keys for your account.
 
-Each account may have up to four API keys at a time. All keys are **"active"** and can be used to call the Lumin Sign API.
+Each account may have up to four API keys at a time. All keys are **"active"** and can be used to call the Lumin API.
 
 Only one key can be set as the **Primary Key**. The **Primary Key** is used to generate the *signature*, which serves to [verify event payload from webhooks](/docs/api/events/#signature-verification).
 
@@ -37,7 +37,7 @@ Only one key can be set as the **Primary Key**. The **Primary Key** is used to g
 
 ## Rotate API Key
 
-You can rotate API Key by generate a new key at [Developer Settings page](https://sign.luminpdf.com/developer/configuration). The old keys will continue to work until you delete them.
+You can rotate API Key by generate a new key at **Developer Settings** page. The old keys will continue to work until you delete them.
 
 You should generate new ones if there’s any chance they’ve been exposed or compromised.
 

--- a/docs/api/changelog.mdx
+++ b/docs/api/changelog.mdx
@@ -1,9 +1,16 @@
 ---
 title: Changelog
-sidebar_position: 1
+sidebar_position: 5
 ---
 
-This changelog lists all additions and updates to the Lumin Sign API.
+This changelog lists all additions and updates to the Lumin API.
+
+### September 08, 2025
+#### Added
+- Add Get Templates endpoint to [Template](/api/templates/).
+- Add Generate Document from Template endpoint to [Template](/api/templates/).
+- Add Create PDF from Template walkthrough.
+
 
 ### July 28, 2024
 #### Added

--- a/docs/api/intro.mdx
+++ b/docs/api/intro.mdx
@@ -4,6 +4,6 @@ sidebar_position: 1
 sidebar_label: Introduction
 ---
 
-The Lumin Sign API Documentation supply information and examples about the endpoints and features in the Lumin Sign API.
+The Lumin API documentation provides information and examples for working with Lumin’s suite of APIs. You can use these APIs to build document workflows including editing, signing, and automation.
 
-The Lumin Sign API is organized around REST. Our API has predictable resource-oriented URLs, uses standard HTTP response codes, authentication, and verbs.
+The Lumin API is REST-based, with predictable resource-oriented URLs. It uses standard HTTP methods, response codes, authentication, and request formats to ensure consistency and ease of integration.

--- a/docs/api/walkthrough/create-pdf-from-template.mdx
+++ b/docs/api/walkthrough/create-pdf-from-template.mdx
@@ -1,0 +1,132 @@
+---
+title: Create a PDF from a Template
+sidebar_position: 2
+---
+
+# Create a PDF from a Template
+
+Lumin templates are document templates that created and saved in the Lumin application. Templates contain placeholders (tags and fields) that you can fill with dynamic data to create customized documents.
+
+**Important notes**
+- Tags and field names use `object.field` syntax (for example: `Client.Name`, `Customer.Name`).
+- Some attributes like `signer_roles` and `signing_type` are specific to **Lumin Sign** templates. These are used when a template will later be sent as a signature request.
+- The same template can be used in two ways: to generate a plain PDF document, or as input for creating a signature request via the signature endpoints.
+
+---
+
+## Understanding Merge Tags and Form Fields
+
+Lumin templates use two types of placeholders that you can fill with dynamic data:
+
+### Merge Tags
+Merge tags are text placeholders embedded directly in the document content. They use the syntax `[text-merge|req|sender|object.field]` and are replaced with actual values during document generation.
+
+**Examples:**
+- `[text-merge|req|sender|Client.Name]` → Replaced with "Acme Corp"
+- `[text-merge|req|sender|Effective.Date]` → Replaced with "2025-08-01"
+
+### Form Fields
+Form fields are interactive elements that users can fill out. They include various input types:
+- **Text**: Single-line text input
+- **Checkbox**: Boolean true/false values
+- **Signature**: Digital signature fields
+- **Radio Button**: Single selection from multiple options
+
+When generating a document from a template, the data you provide will be prefilled into the corresponding form fields.
+
+**Examples:**
+- `Customer.Name` → Text field for customer name
+- `Customer.AgreeToTerms` → Checkbox for agreement
+- `Customer.Signature` → Signature field
+
+---
+
+## Step 1: List available templates
+
+**📖 API Reference:** [GET /templates](/api/list-templates)
+
+```http
+GET /v1/templates
+Authorization: X-API-KEY
+Accept: application/json
+```
+
+**Response**
+
+```json
+{
+  "page": 1,
+  "limit": 25,
+  "total_count": 1,
+  "data": [
+    {
+      "template_id": "sign_abc123",
+      "name": "Mutual NDA",
+      "signing_type": "ORDER",
+      "signer_roles": [
+        { "name": "Customer", "group": 1 }
+      ],
+      "tags": [
+        { "name": "Client.Name", "type": "merge_tag", "is_required": true },
+        { "name": "Effective.Date", "type": "merge_tag", "is_required": false }
+      ],
+      "fields": [
+        { "name": "Customer.Name", "type": "text", "is_required": true },
+        { "name": "Customer.AgreeToTerms", "type": "checkbox", "is_required": true }
+      ],
+      "created_at": 1748456885430,
+      "updated_at": 1748456885430
+    }
+  ]
+}
+```
+
+---
+
+## Step 2: Generate PDF from template
+
+**📖 API Reference**: [POST /templates/template_id/generate-document](/api/generate-document-from-template)
+
+```http
+POST /v1/templates/{template_id}/generate-document
+Authorization: X-API-KEY
+Content-Type: application/json
+Accept: application/json
+```
+
+> To download the PDF directly, set `Accept: application/pdf` — the API returns a binary PDF file.
+
+**Request Body**
+
+Fill the template's tags and fields with your data:
+
+> **Note**: For form fields, only **text** and **checkbox** field types support data prefilling. Signature and radio button fields cannot be prefilled and will appear empty in the generated document.
+
+```json
+{
+  "tags": {
+    "Client.Name": "Acme Corp",
+    "Effective.Date": "2025-08-01"
+  },
+  "fields": {
+    "Customer.Name": "John Doe",
+    "Customer.AgreeToTerms": true
+  },
+  "document_name": "NDA_AcmeCorp"
+}
+```
+
+**Response (JSON)**
+
+```json
+{
+  "document_name": "NDA_AcmeCorp",
+  "signed_url": "https://files.luminpdf.com/download/nda-acmecorp-abc123.pdf",
+  "expires_at": 1766726700
+}
+```
+
+**Response (PDF)**
+
+- When `Accept: application/pdf` is used, the API returns the PDF binary stream directly.
+

--- a/docs/api/walkthrough/text-tag.mdx
+++ b/docs/api/walkthrough/text-tag.mdx
@@ -46,4 +46,4 @@ The size of the form fields created will be defined as follows:
 - The height of the form fields will be fixed to accommodate a font size of 12.
 - The width of the form fields will be equal to the length of the tag (between the pair of square brackets). To make a field longer, add extra underscores `(_)` after the last identifier of the tag.
 
-Example: `[sig1|noreq|signer1____]` will render a wider field than `[sig1|noreq|signer1]`. 
+Example: `[sig1|noreq|signer1|____]` will render a wider field than `[sig1|noreq|signer1]`. 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = themes.dracula;
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Lumin Developer Docs',
-  tagline: 'Add a signing workflow to your app',
+  tagline: 'Build powerful document workflows with the Lumin API',
   url: 'https://luminpdf.github.io',
   baseUrl: '/',
   onBrokenLinks: 'warn',

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,14 +1,15 @@
 openapi: 3.0.0
 info:
   version: 1.0.0
-  title: Lumin Sign Api Reference
+  title: Lumin API Reference
   description: |
-    The Lumin Sign API Reference supplies a wide range of eSignature tools for your application.
+    The Lumin API Reference provides a comprehensive set of tools to integrate document workflows — including editing, eSignatures, and automation — into your applications.
 
-    Some useful links:
-    - [The document repository](https://github.com/luminpdf/luminsign-docs)
-    - [The source API definition for the Lumin Sign API](https://github.com/luminpdf/luminsign-docs/blob/main/openapi.yaml)
-    - [Authentication for using API](/docs/api/authentication/)
+    Useful links:
+    - [Document Repository](https://github.com/luminpdf/luminsign-docs)
+    - [API Definition](https://github.com/luminpdf/luminsign-docs/blob/main/openapi.yaml)
+    - [Authentication Guide](/docs/api/authentication/)
+  termsOfService: https://www.luminpdf.com/terms-of-use/
   contact:
     name: API Support
     email: integration@luminpdf.com
@@ -23,6 +24,8 @@ tags:
     description: Everything about Signature Request
   - name: User
     description: Everything about User
+  - name: Template
+    description: Everything about Template
 paths:
   /signature_request/{signature_request_id}:
     get:
@@ -172,11 +175,11 @@ paths:
                 properties:
                   file_url:
                     type: string
-                    description: The url of the file, which will be downloaded and signed.
+                    description: Signed HTTPS URL to download the document. Expires in 30 minutes.
                   expires_at:
                     type: integer
                     format: unix-epoch
-                    description: When the file url will expire. This is a unix epoch timestamp (miliseconds).
+                    description: Unix epoch timestamp **in seconds** when the signed URL expires.
         '4xx':
           description: Unexpected error
           content:
@@ -241,12 +244,153 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /templates:
+    get: 
+      summary: List Templates
+      description: Returns a paginated list of Lumin templates with essential details embedded for each item.
+      security:
+        - ApiKey: []
+        - BearerAuth: []
+      tags:
+        - Template
+      parameters:
+        - name: page
+          in: query
+          description: Specify which page of the dataset to return (min = 1).
+          schema:
+            type: integer
+            minimum: 1
+          required: false
+        - name: limit
+          in: query
+          description: The number of templates to return per page. One of 10, 25, or 50.
+          schema:
+            type: integer
+            enum: [10, 25, 50]
+          required: false
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TemplateListResponse"
+              example:
+                page: 1
+                limit: 25
+                total_count: 1
+                data:
+                  - template_id: sign_123
+                    name: Mutual NDA
+                    signing_type: ORDER
+                    signer_roles:
+                      - name: Tenant
+                        group: 1
+                      - name: Customer
+                        group: 2
+                    fields:
+                      - name: CustomerName
+                        type: text
+                        is_required: true
+                      - name: HasCompleted
+                        type: checkbox
+                        is_required: true
+                    tags:
+                      - name: ClientName
+                        type: merge_tag
+                        is_required: true
+                      - name: EffectiveDate
+                        type: merge_tag
+                        is_required: true
+                    created_at: 1748456885430
+                    updated_at: 1748456885430
+        '4xx':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /templates/{template_id}/generate-document:
+    post:
+      summary: Generate Document from Template
+      description: |
+        Generates a downloadable PDF document from a specified Lumin template.
+
+        This endpoint takes an existing template identified by `template_id` and produces a static document based on its content and structure.  
+
+        Currently, this operation supports **Lumin Sign templates**, allowing you to prefill merge text tags and form fields, and create a finalized PDF ready for distribution or archiving.
+      security:
+        - ApiKey: []
+        - BearerAuth: []
+      tags:
+        - Template
+      parameters:
+        - in: path
+          name: template_id
+          schema:
+            type: string
+          required: true
+          description: ID of the template to generate document from
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TemplateDTO'
+            example:
+              default:
+                template_id: sign_123
+                tags:
+                  ClientName: ACME Corp
+                  EffectiveDate: 2025-01-01
+                fields:
+                  CustomerName: John Doe
+                  AgreeToTerms: true
+                document_name: Mutual NDA
+      responses:
+        '200':
+          description: Successfully generated document from template
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - document_name
+                  - signed_url
+                  - expires_at
+                properties:
+                  document_name:
+                    type: string
+                    description: Name of the generated document (from input or default).
+                  signed_url:
+                    type: string
+                    format: uri
+                    description: Signed HTTPS URL to download the generated document. Expires in 30 minutes.
+                  expires_at:
+                    type: integer
+                    format: unix-epoch
+                    description: Unix epoch timestamp **in seconds** when the signed URL expires.
+              example:
+                document_name: Mutual NDA
+                document_url: https://files.luminpdf.com/download/nda-acmecorp-abc123.pdf?expires=2025-08-24T10:45:00Z
+                expires_at: 1757219429466
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        '4xx':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   securitySchemes:
     ApiKey:
       type: apiKey
       name: X-API-KEY
       in: header
+      description: |
+        Provide your API key in the `Authorization` header, e.g., `Authorization: API-key`.
     BearerAuth:
       type: http
       scheme: Bearer
@@ -321,7 +465,7 @@ components:
           description: The reason for the status FAILED or REJECTED of the Signature Request.
         signing_type:
           type: string
-          description: The type of signing for the Signature Request.
+          description: Recipient signing flow.
           enum:
             - SAME_TIME
             - ORDER
@@ -459,6 +603,117 @@ components:
         expires_at: 1927510980694
         use_text_tags: false
         signing_type: ORDER
+    TemplateDTO:
+      type: object
+      required:
+        - template_id
+      properties:
+        tags:
+          type: object
+          items:
+            type: object
+          description: |
+            Key–value pairs for **Merge Text Tags** defined in the template.
+            Keys must match tag names. Values replace those tags in the generated document.
+            Currently supports merge tags with syntax: `[text-merge|req|sender|object.field]`.
+        fields:
+          type: object
+          items:
+            type: object
+          description: |
+            Key–value pairs for **Form Fields** defined in the template.
+            Keys must match field names. Values prefill the corresponding fields.
+        document_name:
+          type: string
+          description: Optional custom name for the generated document. Defaults to the template's name if omitted.
+      description: |
+        At least one of `tags` or `fields` may be required when the template defines required tags/fields.
+    Template:
+      type: object
+      required:
+        - template_id
+        - name
+        - tags
+        - fields
+        - created_at
+        - updated_at
+      properties:
+        template_id:
+          type: string
+          description: The unique identifier for the template.
+        name:
+          type: string
+          description: The name of the template.
+        signing_type:
+          allOf:
+            - $ref: '#/components/schemas/SignatureRequest/properties/signing_type'
+            - description: Recipient signing flow.
+        signer_roles:
+          type: array
+          description: Signer roles defined in the template.
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The name of the signer role.
+              group:
+                type: integer
+                description: The signing order of signer for the Signature Request with `signing_type` is `ORDER`.
+        tags:
+          type: array
+          description: Text Tags embedded in the template, which are placeholders added directly in the document using the syntax `[text-merge|req|sender|object.field]`.
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The name/label of the tag.
+              type:
+                type: string
+                description: The type of the text tag.
+                enum: [text-merge, merge_tag]
+              is_required:
+                type: boolean
+                description: Whether the tag must be filled before completing the document.
+        fields:
+          type: array
+          description: Form fields defined in the template.
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The name/label of the form field.
+              type:
+                type: string
+                description: The type of the form field.
+                enum: [text, checkbox, signature, radio_button]
+              is_required:
+                type: boolean
+                description: Whether the form field must be filled before completing the document.
+        created_at:
+          type: string
+          description: The time the template was created.
+        updated_at:
+          type: string
+          description: The time the template was last updated.
+    TemplateListResponse:
+      type: object
+      properties:
+        page:
+          type: integer
+          description: The page number of the dataset.
+        limit:
+          type: integer
+          description: The number of templates to return per page.
+        total_count:
+          type: integer
+          description: The total number of templates.
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Template"
     Error:
       type: object
       required:

--- a/src/components/HomepageFeatures.js
+++ b/src/components/HomepageFeatures.js
@@ -5,11 +5,11 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 const FeatureList = [
   {
-    title: 'Easy to Use',
+    title: 'Easy to Integrate',
     Svg: '/img/easy-to-use.svg',
     description: (
       <>
-        Lumin Sign was designed from the ground up to make it easy to get your signing flow up and running quickly.
+        The Lumin API is designed to help you quickly connect your apps with document workflows — from editing to signing and automation.
       </>
     ),
   },
@@ -18,17 +18,16 @@ const FeatureList = [
     Svg: '/img/focus-to-what-matter.svg',
     description: (
       <>
-        Lumin Sign lets you focus on your app, and we&apos;ll do the chores. Go
-        ahead and work on the functionality that matters.
+        We handle the heavy lifting — storage, compliance, security, and workflow management — so you can focus on delivering the features that matter most to your users.
       </>
     ),
   },
   {
-    title: 'Customize with React',
+    title: 'Flexible & Extensible',
     Svg: '/img/custom-with-react.svg',
     description: (
       <>
-        Extend or customize your Lumin Sign integration using React.
+        Use our APIs to extend or customize Lumin to fit your business needs. Whether it's document editing, eSignature, or data-driven automation, you can adapt Lumin to your workflow.
       </>
     ),
   },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -31,7 +31,7 @@ export default function Home() {
   return (
     <Layout
       title={`Hello from ${siteConfig.title}`}
-      description="Lumin Sign Tutorial - Add a signing workflow to your app">
+      description="Lumin API Tutorial - Build powerful document workflows with the Lumin API">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
- Add new walkthrough guide for creating PDFs from templates
- Update OpenAPI specification with template endpoints
- Reorganize API documentation structure
- Fix server URL and schema definitions
- Update homepage features and intro content